### PR TITLE
Experimentally changed Absent by Design version

### DIFF
--- a/forgeserver.nix
+++ b/forgeserver.nix
@@ -59,7 +59,7 @@
         https://storage.ps2.dev/public/mc/lionfishapi-2.4.jar";
       "MODRINTH_PROJECTS_DEFAULT_VERSION_TYPE" = "beta";
       "MODRINTH_PROJECTS" =
-        "absent-by-design:1.9.0
+        "absent-by-design:1.20.1-1.9.0
         alexs-caves:2.0.2
         alexs-mobs:1.22.9
         almanac:DnzrwvfD


### PR DESCRIPTION
The server is currently unable to launch properly due to an error in the forgeserver.nix file where it is unable to find a matching version. This is an experimental fix to that, as the Modrinth page seems to indicate that the correct version should be 1.20.1-1.9.0, rather than the previous 1.9.0 which we had.